### PR TITLE
Allow guests to access website without logging in

### DIFF
--- a/mnist/index.php
+++ b/mnist/index.php
@@ -3,11 +3,6 @@
     //MNIST Logika - (Makai Balázs)
     $_SESSION['kerdesekSzama'] = 10;
     $_SESSION['jóMegoldások'] = 0;
-
-    // Ha nincs bejelentkezve
-    if($_SESSION["userLoggedIn"] != true) {
-        header('Location: login.php');
-    }
 ?>
 
 <html>
@@ -17,22 +12,46 @@
         <link rel="stylesheet" href="style.css">
     </head>
     <body>
-    <nav class="navtop">
-			<div>
-                <h1>Felhasználó</h1>
-				<a href="profile.php"><i class="fas fa-user-circle"></i>Profil</a>
-				<a href="mnist.php"><i class="fas fa-user-circle"></i>MNIST</a>
-				<a href="ki.php"><i class="fas fa-sign-out-alt"></i>Kijelentkezés</a>
-			</div>
-		</nav>
+    <?php
+        // Felhasználó panel kiiratása, hogyha a felhasználó bevan jelentkezve
+        if(isset($_SESSION['userLoggedIn']) && $_SESSION['userLoggedIn']) {
+            echo '
+            <nav class="navtop">
+                    <div>
+                        <h1>MNIST by humans</h1>
+                        <a href="profile.php"><i class="fas fa-user-circle"></i>Profil</a>
+                        <a href="mnist.php"><i class="fas fa-user-circle"></i>MNIST</a>
+                        <a href="ki.php"><i class="fas fa-sign-out-alt"></i>Kijelentkezés</a>
+                    </div>
+                </nav>
+                ';
 
-        <!-- MNIST LOGIKA - (Makai Balázs)-->
+            if(!empty($_SESSION['elozoJoMegoldasok'])) {
+                echo "<p>Legutolsó alkalommal ".$_SESSION['elozoJoMegoldasok']." jó megoldása volt</p>";
+            }
+        }
+        else {
+            // Bejelentkezés/Regisztrációs sáv vendégeknek
+            echo '
+            <nav class="navtop">
+                    <div>
+                        <h1>MNIST by humans</h1>
+                        <a href="login.php"><i class="fas fa-user-circle"></i>Bejelentkezés</a>
+                        <a href="regisztral.php"><i class="fas fa-user-circle"></i>Regisztrálok</a>
+                        <a href="mnist.php"><i class="fas fa-user-circle"></i>MNIST</a>
+                    </div>
+                </nav>
+                ';
 
-            <?php
-             if(!empty($_SESSION['elozoJoMegoldasok'])) {
-                  echo "<p>Legutolsó alkalommal ".$_SESSION['elozoJoMegoldasok']." jó megoldása volt</p>";
-                 }
-            ?> 
+            // Felhívjük a felhasználó figyelmét, hogy nincsenek bejelentkezve
+            echo '
+                <div class="guestmessage">
+                <p>Maga nincs bejelentkezve!</p>
+                <p>Továbbra is használhatja az oldalt, de korábbi próbálkozásait nem tudja visszanézni, illetve felhasználónevét nem tudja megváltoztatni!</p>
+                </div>
+                ';
+        }
+        ?> 
 
         <!-- RANKLISTA KIÍRÁSA - (Galvács István) -->
         <div id="rangsor">
@@ -57,14 +76,11 @@
             </tr>";
         while($row=mysqli_fetch_assoc($result))
         { 
-            
             echo"<tr>";
             echo "<td width=20 align=center>". $rank .".". "</td>";
             echo"<td width=100>" . $row['felhasznalonev'] . "</td>";
             echo"<td wdith=100 align=center>" . $row['pontszam'] ." Pt" . "</td>";
             echo "</tr>";
-            
-           
          $rank++;
         }  
         echo "</table>";

--- a/mnist/ki.php
+++ b/mnist/ki.php
@@ -2,5 +2,5 @@
 session_start();
 session_destroy();
 
-header('Location: login.php');
+header('Location: index.php');
 ?>

--- a/mnist/mnist.php
+++ b/mnist/mnist.php
@@ -2,12 +2,8 @@
     // MNIST LOGIKA (Makai Balázs) 
     require 'connection.php';
     session_start();
-    $_SESSION['imageSrc'] = "\Project\images\num_1977_[3].png";
 
-    // Ha nincs bejelentkezve
-    if($_SESSION["userLoggedIn"] != true) {
-        header('Location: login.php');
-    } 
+    $_SESSION['imageSrc'] = "\Project\images\&";
 
     //Dobja fel adatbázisba az eredményt
     if($_SESSION['kerdesekSzama'] <= 0) {
@@ -15,6 +11,10 @@
 
         $db = new dbObj();
         $connection = $db->getConnection();
+
+        if(!isset($_SESSION['userLoggedIn']) || !$_SESSION['userLoggedIn']) {
+            $_SESSION["user"] = "Vendég";
+        }
 
         $query = "INSERT INTO rangsor SET felhasznalonev = ' ".$_SESSION["user"]." ', pontszam =' ".$_SESSION["jóMegoldások"]." ' ";
 
@@ -88,16 +88,40 @@
         <title>Mnist</title>
     </head>
     <body>
-    <nav class="navtop">
-			<div>
-                <h1>Felhasználó</h1>
-				<a href="profile.php"><i class="fas fa-user-circle"></i>Profil</a>
-				<a href="mnist.php"><i class="fas fa-user-circle"></i>MNIST</a>
-				<a href="ki.php"><i class="fas fa-sign-out-alt"></i>Kijelentkezés</a>
-			</div>
-		</nav>
-        <!-- MNIST LOGIKA (Makai Balázs) -->
+    <?php
+        // Felhasználó panel kiiratása, hogyha a felhasználó bevan jelentkezve
+        if(isset($_SESSION['userLoggedIn']) && $_SESSION['userLoggedIn']) {
+            echo '
+            <nav class="navtop">
+                    <div>
+                        <h1>MNIST by humans</h1>
+                        <a href="profile.php"><i class="fas fa-user-circle"></i>Profil</a>
+                        <a href="mnist.php"><i class="fas fa-user-circle"></i>MNIST</a>
+                        <a href="ki.php"><i class="fas fa-sign-out-alt"></i>Kijelentkezés</a>
+                    </div>
+                </nav>
+                ';
+        }
+        else {
+            // Bejelentkezés/Regisztrációs sáv
+            echo'
+            <nav class="navtop">
+                    <div>
+                        <h1>MNIST by humans</h1>
+                        <a href="login.php"><i class="fas fa-user-circle"></i>Bejelentkezés</a>
+                        <a href="regisztral.php"><i class="fas fa-user-circle"></i>Regisztrálok</a>
+                        <a href="mnist.php"><i class="fas fa-user-circle"></i>MNIST</a>
+                    </div>
+                </nav>
+                ';
 
+            // Felhívjük a felhasználó figyelmét, hogy nincs bejelentkezve
+            echo'
+                <div class="guestmessage">
+                <p>MNIST vendégként</p>
+                ';
+        }
+        ?> 
             <img src="Resources\Images\<?php echo getRandomImage(); ?>">
 
             <p> Helyes válaszok száma: <?php echo $_SESSION["jóMegoldások"] ?> </p>

--- a/mnist/profile.php
+++ b/mnist/profile.php
@@ -5,7 +5,7 @@ session_start();
 
 // Ha a felhasználó nincs belépve
 if($_SESSION["userLoggedIn"] != true) {
-	header('Location: login.php');
+	header('Location: index.php');
 } 
 
 $server = 'localhost'; 
@@ -33,7 +33,7 @@ $eredmeny->close();
 	<body class="loggedin">
 		<nav class="navtop">
 			<div>
-                <h1>Felhasználó</h1>
+                <h1>MNIST by humans</h1>
 				<a href="profile.php"><i class="fas fa-user-circle"></i>Profil</a>
 				<a href="mnist.php"><i class="fas fa-user-circle"></i>MNIST</a>
 				<a href="ki.php"><i class="fas fa-sign-out-alt"></i>Kijelentkezés</a>


### PR DESCRIPTION
Changelog:
- Visiting any link other than login no longer redirects you to the login page, instead, now only profile related pages do.
- The navigation bars on mnist.php and index.php now change depending on whether the user's logged in or not.
- Filling out MNIST as a guest uploads a record to the database with the username "Guest".
- Changed navigation bar title from "Felhasználó" to "MNIST by humans" on all pages.